### PR TITLE
Investigate savings account future growth bug

### DIFF
--- a/budget-master/frontend/src/components/SavingsSummary.tsx
+++ b/budget-master/frontend/src/components/SavingsSummary.tsx
@@ -209,11 +209,13 @@ const SavingsSummary: React.FC<SavingsSummaryProps> = ({ savings }) => {
       });
     });
 
-    // Extend Savings Account with minimal growth (1%)
+    // Keep Savings Account as historical data only (no automatic projections)
     const savingsDataset = historicalDatasets.find(ds => ds.category === 'Savings Account');
-    if (savingsDataset && savingsDataset.finalValue > 0) {
-      const savingsProjections = calculateProjections(savingsDataset.finalValue, 0.01, 240);
-      savingsDataset.data = [...savingsDataset.data.filter(val => val !== null), ...savingsProjections];
+    if (savingsDataset) {
+      // Remove any null values and keep only historical data
+      savingsDataset.data = savingsDataset.data.filter(val => val !== null);
+      // Extend with nulls for future months to maintain chart structure
+      savingsDataset.data = [...savingsDataset.data, ...new Array(240).fill(null)];
       savingsDataset.label = 'Savings Account';
     }
 


### PR DESCRIPTION
Remove automatic 1% growth projection from Savings Account trend graph to prevent misleading future growth.

Previously, the Savings Account trend graph would automatically project 1% annual growth for 20 years if `finalValue > 0`, causing the graph to show future growth even without explicit future allocations. This fix ensures the graph only displays historical data for savings accounts.

---
<a href="https://cursor.com/background-agent?bcId=bc-df88fb89-3c2a-44fb-98b6-3425bea69c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df88fb89-3c2a-44fb-98b6-3425bea69c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

