### PR TITLE
Investigate percentage decimal precision bug

### DIFF
--- a/budget-master/frontend/src/components/SavingsSummary.tsx
+++ b/budget-master/frontend/src/components/SavingsSummary.tsx
@@ -196,7 +196,7 @@ const SavingsSummary: React.FC<SavingsSummaryProps> = ({ savings }) => {
         const projectionData = [...new Array(months.length).fill(null), ...projections];
         
         projectionDatasets.push({
-          label: `${category} ${(rate * 100)}% Growth`,
+          label: `${category} ${(rate * 100).toFixed(0)}% Growth`,
           data: projectionData,
           borderColor: getProjectionColor(category, rate),
           backgroundColor: getProjectionColor(category, rate) + '10',


### PR DESCRIPTION
Fix floating-point precision in trend graph labels to display clean integer percentages.

JavaScript's floating-point arithmetic can cause numbers like `0.07 * 100` to result in `7.000000000000001` instead of exactly `7`. This PR rounds the calculated percentage to the nearest integer for display in chart legends and tooltips.

---
<a href="https://cursor.com/background-agent?bcId=bc-92e9e28f-c1ec-4658-81cf-294bcc6e00d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92e9e28f-c1ec-4658-81cf-294bcc6e00d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

